### PR TITLE
OAuth refresh tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.RData
+.Rhistory

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -106,7 +106,7 @@ function (oauthDomain = transmartClientEnv$transmartDomain, prefetched.request.t
         return(TRUE)
     }
 
-    ping <- .transmartServerGetRequest("/oauth/verify", accept.type = "default")
+    ping <- .transmartServerGetRequest("/oauth/inspectToken", accept.type = "default")
     if (getOption("verbose")) { message(paste(ping, collapse = ": ")) }
 
     if (!is.null(ping)) {

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -240,32 +240,31 @@ function(apiCall, httpHeaderFields, accept.type = "default", progress = .make.pr
 }
 
 
-.listToDataFrame <- function(list) {
+.listToDataFrame <- function(l) {
     # TODO: (timdo) dependency on 'plyr' package removed; figure out whether dependency is present elsewhere, or remove dependency
     # add each list-element as a new row to a matrix, in two passes
     # first pass: go through each list element, unlist it and remember future column names
     columnNames <- c()
-    if (length(list) > 0) {
-        for (i in 1:(length(list))) {
-            cat('i: ', i, '\n')
-            list[[i]] <- unlist(list[[i]])
-            columnNames <- union(columnNames, names(list[[i]]))
+    if (length(l) > 0) {
+        for (i in 1:(length(l))) {
+            l[[i]] <- unlist(l[[i]])
+            columnNames <- union(columnNames, names(l[[i]]))
         }
     }
     
     # second pass: go through each list element and add its elements to correct column
-    df <- matrix(nrow = length(list), ncol = length(columnNames))
-    if (length(list) > 0) {
-        for (i in 1:(length(list))) {
-            df[i, match(names(list[[i]]), columnNames)] <- list[[i]]
+    df <- matrix(nrow = length(l), ncol = length(columnNames))
+    if (length(l) > 0) {
+        for (i in 1:(length(l))) {
+            df[i, match(names(l[[i]]), columnNames)] <- l[[i]]
         }
     }
     colnames(df) <- columnNames
 
     # check whether list contains valid row names, and if true; use them
-    if (length(list) < 1 || is.null(names(list)) || is.na(names(list)) || length(names(list)) != length(list)) { 
+    if (length(l) < 1 || is.null(names(l)) || is.na(names(l)) || length(names(l)) != length(l)) { 
         rownames(df) <- NULL
-    } else { rownames(df) <- names(list) }
+    } else { rownames(df) <- names(l) }
     # convert matrix to data.frame
     as.data.frame(df, stringsAsFactors = FALSE)
 }

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -186,20 +186,25 @@ function(apiCall, httpHeaderFields, accept.type = "default", progress = .make.pr
     # add each list-element as a new row to a matrix, in two passes
     # first pass: go through each list element, unlist it and remember future column names
     columnNames <- c()
-    for (i in 1:(length(list))) {
-        list[[i]] <- unlist(list[[i]])
-        columnNames <- union(columnNames, names(list[[i]]))
+    if (length(list) > 0) {
+        for (i in 1:(length(list))) {
+            cat('i: ', i, '\n')
+            list[[i]] <- unlist(list[[i]])
+            columnNames <- union(columnNames, names(list[[i]]))
+        }
     }
     
     # second pass: go through each list element and add its elements to correct column
     df <- matrix(nrow = length(list), ncol = length(columnNames))
-    for (i in 1:(length(list))) {
-        df[i, match(names(list[[i]]), columnNames)] <- list[[i]]
+    if (length(list) > 0) {
+        for (i in 1:(length(list))) {
+            df[i, match(names(list[[i]]), columnNames)] <- list[[i]]
+        }
     }
     colnames(df) <- columnNames
 
     # check whether list contains valid row names, and if true; use them
-    if (is.null(names(list)) || is.na(names(list)) || length(names(list)) != length(list)) { 
+    if (length(list) < 1 || is.null(names(list)) || is.na(names(list)) || length(names(list)) != length(list)) { 
         rownames(df) <- NULL
     } else { rownames(df) <- names(list) }
     # convert matrix to data.frame

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -200,7 +200,7 @@ refreshToken <- function(oauthDomain = transmartClientEnv$transmartDomain) {
 .serverMessageExchange <- 
 function(apiCall, httpHeaderFields, accept.type = "default", progress = .make.progresscallback.download()) {
     if (any(accept.type == c("default", "hal"))) {
-        if (accept.type == "hal") { httpHeaderFields <- c(httpHeaderFields, accept = "application/hal+json") }
+        if (accept.type == "hal") { httpHeaderFields <- c(httpHeaderFields, Accept = "application/hal+json;charset=UTF-8") }
         result <- getURL(paste(sep="", transmartClientEnv$db_access_url, apiCall),
                 verbose = getOption("verbose"),
                 httpheader = httpHeaderFields)

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -70,8 +70,8 @@ function (oauthDomain = transmartClientEnv$transmartDomain, prefetched.request.t
             "/oauth/authorize?response_type=code&client_id=", 
             transmartClientEnv$client_id,
             "&client_secret=", transmartClientEnv$client_secret,
-            "&redirect_uri=", transmartClientEnv$oauthDomain,
-            "/oauth/verify")
+            "&redirect_uri=", URLencode(transmartClientEnv$oauthDomain, TRUE),
+            URLencode("/oauth/verify", TRUE))
 
     if (is.null(prefetched.request.token)) {
         cat("Please visit the following url to authenticate this RClient (enter nothing to cancel):\n\n",
@@ -90,9 +90,9 @@ function (oauthDomain = transmartClientEnv$transmartDomain, prefetched.request.t
             "/oauth/token?grant_type=authorization_code&client_id=",
             transmartClientEnv$client_id,
             "&client_secret=", transmartClientEnv$client_secret,
-            "&code=", request.token,
-            "&redirect_uri=", transmartClientEnv$oauthDomain,
-            "/oauth/verify")
+            "&code=", URLencode(request.token, TRUE),
+            "&redirect_uri=", URLencode(transmartClientEnv$oauthDomain, TRUE),
+            URLencode("/oauth/verify", TRUE))
 
     oauthResponse <- NULL
     tryCatch(oauthResponse <- getURL(oauth.exchange.token.url, verbose = getOption("verbose")), 
@@ -122,9 +122,9 @@ refreshToken <- function(oauthDomain = transmartClientEnv$transmartDomain) {
                         "/oauth/token?grant_type=refresh_token",
                         "&client_id=", transmartClientEnv$client_id,
                         "&client_secret=", transmartClientEnv$client_secret,
-                        "&refresh_token=", transmartClientEnv$refresh_token,
-                        "&redirect_uri=", transmartClientEnv$oauthDomain,
-                        "/oauth/verify",
+                        "&refresh_token=", URLencode(transmartClientEnv$refresh_token, TRUE),
+                        "&redirect_uri=", URLencode(transmartClientEnv$oauthDomain, TRUE),
+                        URLencode("/oauth/verify", TRUE),
                         "")
     
     oauthResponse <- NULL

--- a/R/getStudies.R
+++ b/R/getStudies.R
@@ -24,18 +24,22 @@
 getStudies <- function(name.match = "", as.data.frame = TRUE, cull.columns = TRUE) {
     .checkTransmartConnection()
 
-    serverResult <- .transmartServerGetRequest("/studies", accept.type = "default")
-    listOfStudies <- serverResult #$studies
+    serverResult <- .transmartServerGetRequest("/studies", accept.type = "hal")
+    listOfStudies <- serverResult$studies
+    
+    n <- length(listOfStudies)
+    if (n == 0) {
+        message("Empty list of studies received.")
+    }
     
     studyNames <- sapply(listOfStudies, FUN = function(x) { x[["id"]] })
     names(listOfStudies) <- studyNames
     listOfStudies <- listOfStudies[ grep(name.match, studyNames) ]
-
     if (as.data.frame) {
         dataFrameStudies <- .listToDataFrame(listOfStudies)
         if (cull.columns) {
             columnsToKeep <- match(c("id", "api.link.self.href", "ontologyTerm.fullName"), names(dataFrameStudies))
-            if (any(is.na(columnsToKeep))) {
+            if (n > 0 && any(is.na(columnsToKeep))) {
                 warning("There was a problem culling columns. You can try again with cull.columns = FALSE.")
                 message("Sorry. You've encountered a bug.\n",
                         "You can help fix it by contacting us. Type ?transmartRClient for contact details.\n", 

--- a/R/getStudies.R
+++ b/R/getStudies.R
@@ -24,8 +24,8 @@
 getStudies <- function(name.match = "", as.data.frame = TRUE, cull.columns = TRUE) {
     .checkTransmartConnection()
 
-    serverResult <- .transmartServerGetRequest("/studies", accept.type = "hal")
-    listOfStudies <- serverResult$studies
+    serverResult <- .transmartServerGetRequest("/studies", accept.type = "default")
+    listOfStudies <- serverResult #$studies
     
     studyNames <- sapply(listOfStudies, FUN = function(x) { x[["id"]] })
     names(listOfStudies) <- studyNames


### PR DESCRIPTION
Implements the use of OAuth refresh tokens in the connection manager. When establishing a connection fails, reauthentication is tried using the refresh token that has been acquired from the previous authentication. 
This has been tested with the transmartApp from https://github.com/transmart/transmartApp.